### PR TITLE
Show long snack names

### DIFF
--- a/GuiApp/kv/clickableTable.kv
+++ b/GuiApp/kv/clickableTable.kv
@@ -1,15 +1,17 @@
 #:kivy 2.1.0
 
 <ClickableTableColumnLabel>:
-    size_hint: 1, None
+    size_hint_y: None
     text: 'COLUMN NAME'
     bold: True
     height: '50dp'
 
 <ClickableTableColumnEntryLabel>:
     text: 'ENTRY NAME'
-    size_hint: 1, None
-    height: '50dp'
+    text_size: self.width, self.height
+    height: self.texture_size[1]
+    halign: "center"
+    valign: 'middle'
 
 <ClickableTableEntry>:
     rows: 1
@@ -55,6 +57,7 @@
             GridLayout:
                 rows: 1
                 size_hint: 1, None
+                padding: ["10dp", 0]
                 height: '50dp'
                 id: tableHeader
                 canvas.after:

--- a/GuiApp/widgets/buyScreen.py
+++ b/GuiApp/widgets/buyScreen.py
@@ -35,11 +35,13 @@ class BuyScreenContent(GridLayout):
             }
 
         self.snackListInventory = ClickableTable(
-            ["Snack name", "Quantity", "Price"],
+            columns=["Snack name", "Quantity", "Price"],
+            columnExamples=["Long snack name", "Quantity", "Price"],
             onEntryPressedCallback=self.itemClickedInInventory,
         )
         self.snackListShoppingCart = ClickableTable(
-            ["Snack name", "Quantity", "Price"],
+            columns=["Snack name", "Quantity", "Price"],
+            columnExamples=["Long snack name", "Quantity", "Price"],
             onEntryPressedCallback=self.itemClickedInShoppingCart,
         )
 

--- a/GuiApp/widgets/editSnacksScreen.py
+++ b/GuiApp/widgets/editSnacksScreen.py
@@ -16,7 +16,8 @@ class EditSnacksScreenContent(GridLayout):
         super().__init__(**kwargs)
         self.screenManager = screenManager
         self.snackTable = ClickableTable(
-            ["Snack name", "Quantity", "Price", "Image ID"],
+            columns=["Snack name", "Quantity", "Price", "Image ID"],
+            columnExamples=["Long snack name", "100", "43.43", "AnImageId"],
             onEntryPressedCallback=self.onSnackEntryPressed,
         )
         self.add_widget(self.snackTable)

--- a/GuiApp/widgets/editUsersScreen.py
+++ b/GuiApp/widgets/editUsersScreen.py
@@ -18,7 +18,8 @@ class EditUsersScreenContent(GridLayout):
         super().__init__(**kwargs)
         self.screenManager = screenManager
         self.usersTable = ClickableTable(
-            ["First name", "Last name", "User ID", "Total credits"],
+            columns=["First name", "Last name", "User ID", "Total credits"],
+            columnExamples=["LongName", "LongLastName", "23", "100.00"],
             onEntryPressedCallback=self.onUserEntryPressed,
         )
         self.add_widget(self.usersTable)

--- a/GuiApp/widgets/historyScreen.py
+++ b/GuiApp/widgets/historyScreen.py
@@ -20,7 +20,8 @@ class HistoryScreenContent(GridLayout):
         self.screenManager = screenManager
 
         self.historyTable = ClickableTable(
-            ["Date", "Credits before", "Credits after", "Type"],
+            columns=["Date", "Credits before", "Credits after", "Type"],
+            columnExamples=["2025-01-12 15:04:31", "10000.00", "10000.00", "Purchase"],
             onEntryPressedCallback=self.onHistoryEntryPressed,
         )
 

--- a/GuiApp/widgets/popups/purchaseSummaryPopup.py
+++ b/GuiApp/widgets/popups/purchaseSummaryPopup.py
@@ -26,7 +26,8 @@ class PurchaseSummaryPopup(Popup):
         self.ids["totalPriceLabel"].text = f"{totalPrice:.2f}"
 
         self.snackTable = ClickableTable(
-            ["Snack name", "Quantity", "Price"],
+            columns=["Snack name", "Quantity", "Price"],
+            columnExamples=["Long snack name", "100", "43.43"],
             onEntryPressedCallback=None,
             size_hint_x=0.5,
         )


### PR DESCRIPTION
I'm widening the longer columns based on a provided entry example when creating the table. Also made it possible for snack entries to have two rows. Should be enough for very long snack names
![image](https://github.com/user-attachments/assets/7c6b80e3-5827-48cc-adc9-980b6f191406)
![image](https://github.com/user-attachments/assets/2e2a93d6-65db-4ea8-aec8-d1a82140f9dd)
![image](https://github.com/user-attachments/assets/1395a70d-7914-4cc9-8ff0-d6091c4e450b)
