### PR TITLE
Chore/vscode-test-settings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,36 +31,6 @@
             ],
             "console": "integratedTerminal",
             "justMyCode": true
-        },
-        {
-            "name": "pytest: Current File",
-            "type": "python",
-            "request": "launch",
-            "module": "pytest",
-            "args": [
-                "${file}" "-rP"
-            ],
-            "env": {
-                "PYTHONPATH": "${workspaceFolder}/GuiApp"
-            },
-            "console": "integratedTerminal",
-            "justMyCode": true
-        },
-        {
-            "name": "pytest: All tests",
-            "type": "python",
-            "request": "launch",
-            "module": "pytest",
-            "args": [
-                "${workspaceFolder}/GuiApp/tests",
-                "-rP",
-                "--maxfail=5"
-            ],
-            "env": {
-                "PYTHONPATH": "${workspaceFolder}/GuiApp"
-            },
-            "console": "integratedTerminal",
-            "justMyCode": true
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,8 @@
         "dev env"
     ],
     "python.testing.pytestArgs": [
-        "GuiApp/tests"
+        "GuiApp/tests",
+        "-rP" // Show output for passed tests
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,10 @@
 {
     "conventionalCommits.scopes": [
         "dev env"
-    ]
+    ],
+    "python.testing.pytestArgs": [
+        "GuiApp/tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
 }


### PR DESCRIPTION
Since VS Code has support for pytest, move launch configurations and respective args to workspace settings file