### PR TITLE
fix: RFIDReader does not return string type on real read

### DIFF
--- a/GuiApp/RFIDReader.py
+++ b/GuiApp/RFIDReader.py
@@ -79,6 +79,8 @@ class RFIDReader:
             try:
                 while not self.running.is_set():
                     card_id = reader.read_id_no_block()
+                    if card_id is not None and not isinstance(card_id, str):
+                        card_id = str(card_id)
                     if (
                         card_id is not None
                         and card_id != self.last_read_id


### PR DESCRIPTION
## Summary

The real `SimpleMFRC522.read_id_no_block()` returns an **integer** on Raspberry Pi hardware, but all downstream consumers (database layer, callbacks) expect a **string**. This causes an `AssertionError` in `getPatronIdByCardId()` which calls `assert isinstance(cardId, str)`.

## Changes

- `GuiApp/RFIDReader.py`: Added a type conversion in `reader_task()` — when the real reader returns a non-string, non-`None` value, it is explicitly converted to `str` before being passed to the callback.

## Testing

- All existing tests pass (43 tests: login, create user, edit users, top up)
- Pre-commit hooks: Black and pylint pass

Closes #321