### PR TITLE
fix(logging): 🐛 Use script-relative log path instead of CWD-relative

### DIFF
--- a/GuiApp/logger.py
+++ b/GuiApp/logger.py
@@ -19,7 +19,8 @@ import time
 from typing import List
 
 
-LOG_DIR = "logs"
+_LOGGER_DIR = os.path.dirname(os.path.abspath(__file__))
+LOG_DIR = os.path.join(os.path.dirname(_LOGGER_DIR), "logs")
 LOG_FILE = os.path.join(LOG_DIR, "snackattack.log")
 
 # Default format strings


### PR DESCRIPTION
When launched by cron, the working directory is typically `$HOME`, so the old relative `"logs"` path landed in `/home/pi/logs/` instead of the project's `logs/` directory.

Fix: derive `LOG_DIR` from `logger.py`'s location on disk so it always resolves inside the project root, regardless of how the app is launched.